### PR TITLE
Add 'Other' language

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -267,9 +267,11 @@ sorted_languages.sort(function(a, b) {return b[1] - a[1]});
 
 languages = sorted_languages;
 
+var display_languages = 7;
+
 for (var i = 0; i < languages.length; i++) {
 
-    if (i < 7) {
+    if (i < display_languages) {
         var ol_li = document.createElement("LI");
         var ol_li_a = document.createElement("A");
         ol_li_a.href = github_colors[languages[i][0]].url;
@@ -302,6 +304,45 @@ for (var i = 0; i < languages.length; i++) {
 
         ol_lang.appendChild(ol_li);
         div2.appendChild(span_color);
+    }
+    else {
+	var ol_li = document.createElement("LI");
+	var ol_li_a = document.createElement("A");
+        ol_li_a.href = "#";
+
+	var percentage = total_size;
+	for (var j = 0; j < i; j++)
+	    percentage -= languages[j][1];
+	percentage /= total_size;
+
+	var span_language_color = document.createElement("SPAN");
+	span_language_color.className = "color-block language-color";
+	span_language_color.style.backgroundColor = "#ededed";
+
+	var span_language = document.createElement("SPAN");
+	span_language.className = "lang";
+	span_language.innerHTML = "   Other";
+
+	var span_percent = document.createElement("SPAN");
+	span_percent.className = "percent";
+	span_percent.innerHTML = "   " + (percentage * 100).toFixed(1) + "%";
+
+        ol_li_a.appendChild(span_language_color);
+        ol_li_a.appendChild(span_language);
+        ol_li_a.appendChild(span_percent);
+
+        ol_li.appendChild(ol_li_a);
+
+	var span_color = document.createElement("SPAN");
+	span_color.className = "language-color";
+	span_color.style.width = percentage + "%";
+	span_color.style.backgroundColor = "#ededed";
+	span_color.innerHTML = "   Other";
+
+	ol_lang.appendChild(ol_li);
+	div2.appendChild(span_color);
+
+	break;
     }
 
 }


### PR DESCRIPTION
Add "Other" span when the number of languages is greater than `display_languages`, default 7. The "Other" language will represent the remaining percentage not taken up by the rest of the languages (literally 100 - the rest of the percentages). Note that this means that, with the current accuracy issues, "Other" will often show up as 80% or more of a profile's fluency; however, once the percentage calculations are fixed the displayed percentage will be correct.
